### PR TITLE
New OAuth 2.0 URLs

### DIFF
--- a/src/Provider/Wrike.php
+++ b/src/Provider/Wrike.php
@@ -20,7 +20,7 @@ class Wrike extends AbstractProvider
      */
     public function getBaseAuthorizationUrl()
     {
-        return 'https://www.wrike.com/oauth2/authorize/v4';
+        return 'https://login.wrike.com/oauth2/authorize/v4';
     }
     
     /**
@@ -32,7 +32,7 @@ class Wrike extends AbstractProvider
      */
     public function getBaseAccessTokenUrl(array $params)
     {
-        return 'https://www.wrike.com/oauth2/token';
+        return 'https://login.wrike.com/oauth2/token';
     }
     
     /**


### PR DESCRIPTION
## What?
I updated the OAuth 2.0 urls.

## Why?
Wrike is changing OAuth 2.0 URLs, old OAuth 2.0 URLs will be supported until May 2022